### PR TITLE
Fix for faulty Nginx Config

### DIFF
--- a/site/trendspedia/DEPLOY.md
+++ b/site/trendspedia/DEPLOY.md
@@ -26,13 +26,33 @@ likelihood of this is small. In most cases it's sufficient to
 restart Gunicorn. If nginx is not already running simply
 use the `nginx` command without arguments to start it up.
 
+## wsgi.py
+Make sure `DJANGO_SETTINGS_MODULE` in `cs3281/wsgi.py` is set to
+`settings.deployment`. During development you may set this to
+`settings.development`.
+
+## Other options
+Make sure MySQL, MongoDB and RabbitMQ are running
+
+``
+mysqld  
+mongod --dbpath={where db directory is}
+rabbitmq-server -detached
+``
+
+Make sure there is at least one celery worker scraping URLs in tweets.
+``
+python manage.py celery -A twitter.taskrunner worker
+``
+
 ## Gunicorn
 Gunicorn is the server that runs the Django code. It is essentially
 a production-ready replacement to the `manage.py runserver` option 
 used for development.
 
 To run it, use  
-`gunicorn cs3281.wsgi:application --bind 127.0.0.1:8001`  
+`gunicorn cs3281.wsgi:application --bind 127.0.0.1:8001 -D`  
 
+The `-D` runs it in daemonized mode. Adjust other options as required.
 The port is important because this port is where nginx will send
 requests to.

--- a/site/trendspedia/nginx_orig.conf
+++ b/site/trendspedia/nginx_orig.conf
@@ -47,6 +47,8 @@ http {
             proxy_pass http://127.0.0.1:8001;
             proxy_set_header X-Forwarded-Host $server_name;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
             add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
         }
 


### PR DESCRIPTION
Fix for twitter callback URL being 127.0.0.1:8001 instead of trendspedia.com

The problem was that gunicorn wasn't aware that it was behind a proxy and was sending what it thought was the global IP. Fixed nginx config to tell gunicorn about the whole proxy thing. Remote already updated so no further steps are necessary.

Also took the chance to edit DEPLOY.md to add in some missing instructions.