### PR TITLE
Background crawling implemented

### DIFF
--- a/site/trendspedia/celery_queue/tokens_producer.py
+++ b/site/trendspedia/celery_queue/tokens_producer.py
@@ -77,7 +77,11 @@ def producer(logger):
         channel.queue_declare(queue=body)
         channel.basic_publish(exchange='',
                           routing_key=body,
-                          body=json.dumps(tq.retrieveToken(body)))
+                          body=json.dumps([
+                            tq.retrieveToken(body),
+                            tq.getMinTimeBetweenUses(body)
+                            ])
+                          )
         connection.close()
 
     channel.basic_consume(callback,

--- a/site/trendspedia/cs3281/wsgi.py
+++ b/site/trendspedia/cs3281/wsgi.py
@@ -38,3 +38,8 @@ import threading
 t = threading.Thread(target=tokens_producer.run_producer)
 t.daemon = True
 t.start()
+
+from twitter import crawler
+t = threading.Thread(target=crawler.start)
+t.daemon = True
+t.start()

--- a/site/trendspedia/twitter/crawler.py
+++ b/site/trendspedia/twitter/crawler.py
@@ -1,0 +1,82 @@
+import datetime, time, threading, logging, json, inspect, pdb
+import pika
+from twitter.mongoModels import Topics
+from twython import Twython
+from django.conf import settings
+from celery_queue import tokens_queue, tokens_producer
+from twitter.helper import Helper
+
+## Monitors and makes sure that the thread is always running
+logger = tokens_producer.createLogger("crawler_log", True)
+def start():
+  try:
+    t = threading.Thread(target=run)
+    t.daemon = True
+    t.start()
+    while True:
+      if not t.is_alive():
+        logger.critical(json.dumps({"message":"Crawler crashed, restarting thread."}))
+        t = threading.Thread(target=run)
+        t.daemon = True
+        t.start()
+      time.sleep(30)
+  except (KeyboardInterrupt, SystemExit):
+    return
+
+def run():
+  logger.info(json.dumps({"message":"Crawler started."}))
+  while True:
+    topic = Topics.objects.order_by('priority','lastSearchedAt').first()
+    if topic is None:
+      logger.info("Nothing to crawl")
+      time.sleep(3);
+      continue
+    logger.info("Searching query = '" + topic.query + "'")
+    #Search returns the time to sleep so that searches can continue without
+    #hiccups from twitter, need to improve the design later
+    timetosleep = search(topic.query, topic.pageID, topic.sinceID)
+    topic.priority = topic.priority + 1
+    topic.lastSearchedAt = datetime.datetime.now()
+    topic.save()
+    #Sleep just enough to circumvent the twitter limits
+    logger.info("Sleeping for " + str(timetosleep) + " seconds")
+    time.sleep(timetosleep)
+
+def search(query, pageID, since):
+  #query, pageID, result_type=recent, count=100
+  #Get a token
+  channel = pika.BlockingConnection(
+    pika.ConnectionParameters(host='localhost')).channel()
+  channel.queue_declare(queue='tokens_queue')
+  channel.basic_publish(exchange='',
+    routing_key='tokens_queue',
+    body='search')
+  channel.queue_declare(queue='search')
+  method_frame, header_frame, token = channel.basic_get(queue='search')
+  print "receiver_dump = ", token
+  token, timetosleep = json.loads(token)
+  timetosleep = timetosleep * 1.5 # buffer time
+  t = Twython(
+        app_key=settings.TWITTER_CONSUMER_KEY,
+        app_secret=settings.TWITTER_CONSUMER_SECRET,
+        oauth_token=token['oauth_token'],
+        oauth_token_secret=token['oauth_token_secret'])
+  queryResults = t.search(q=query, result_type='recent', count=100, since_id=since)
+  Helper().updateWikiArticleTweet(pageID, queryResults)
+  # Copied from search_with_tokens in twitter/views.py
+  # ----------
+  # Get the correct logger based on convention:
+  # {APP}.{FILE}.{FUNCTION} = __name__.'.'.inspect.stack()[0][3]
+  # Need to evaulate performance of 'inspect' library as print function name
+  # is not supported by Python
+  # print __name__+"."+inspect.stack()[0][3]
+  logger2 = logging.getLogger(__name__+"."+inspect.stack()[0][3])
+  # Fake infomation, to be updated later
+  logger2.info(json.dumps({
+      "pageID": pageID, # Pass the correct pageID here
+      "queryType": "search",
+      "query": queryResults["search_metadata"]["query"],
+      "tweetsCount": queryResults["search_metadata"]["count"],
+      "source": 'TwitterAPI',
+  }))
+  return timetosleep

--- a/site/trendspedia/twitter/mongoModels.py
+++ b/site/trendspedia/twitter/mongoModels.py
@@ -52,6 +52,13 @@ class SimpleTweet(EmbeddedDocument):
     user = ReferenceField(TwitterUser)
     pk = StringField(default="")
 
+#
+class Topic(Document):
+    priority = IntField(default=0)
+    lastSearchedAt = DateTimeField(default=datetime.datetime.now)
+    pageID = StringField(required=True)
+    query = StringField(required=True, unique=True)
+
 class WikiArticle(Document):
     meta = {
         'collection': 'wiki_article',

--- a/site/trendspedia/twitter/mongoModels.py
+++ b/site/trendspedia/twitter/mongoModels.py
@@ -53,11 +53,12 @@ class SimpleTweet(EmbeddedDocument):
     pk = StringField(default="")
 
 #
-class Topic(Document):
+class Topics(Document):
     priority = IntField(default=0)
     lastSearchedAt = DateTimeField(default=datetime.datetime.now)
-    pageID = StringField(required=True)
-    query = StringField(required=True, unique=True)
+    pageID = StringField(required=True, unique=True)
+    query = StringField(required=True)
+    sinceID = StringField()
 
 class WikiArticle(Document):
     meta = {

--- a/site/trendspedia/twitter/views.py
+++ b/site/trendspedia/twitter/views.py
@@ -28,7 +28,6 @@ from rest_framework.response import Response
 from wikipedia.views import JSONResponse
 from pymongo import Connection
 from twitter.helper import Helper
-
 # Global variable ??? How to fix
 oauth = None
 
@@ -592,15 +591,34 @@ def hotImage(request):
 
 
 #DY
-# tweets from mongoDB
 import pymongo
+# tweets from mongoDB
 def getTweetsfromDB(request):
     con = Connection()
     db = con['cs3281']
-    tweetsDB = db['tweets']
-    
     params = request.GET
-    searchKey = params['title']
+    print "params = "
+    print params
+    # Insert query into Topic DB if does not exist, if exist then
+    # update priority to 1
+    topic = db['topics'].find_one({"pageID": params['pageID']})
+    if topic is None:
+        topic = {}
+        print params
+        topic['query'] = params['query']
+        topic['pageID'] = params['pageID']
+        topic['priority'] = 1
+        db['topics'].insert(topic)
+    else:
+        db['topics'].update({"pageID": params['pageID']},
+            {"$set":{
+                "priority": 1,
+                "sinceID": params.get('since_id')
+            }
+        })
+
+    tweetsDB = db['tweets']
+    searchKey = params['query']
     pageID = params['pageID']
 
     from bson import json_util


### PR DESCRIPTION
Instead of frontend calling the `/twitter/api/search` route, I've made it such that the frontend calls the `twitter/tweetsFromDB` route. This would not trigger any new twitter searches but simply return the latest tweets from the database.

The actual twitter calls is handled by a separate thread called crawler. There is a new collection in MongoDB called Topic which represents wikipedia topics that must be crawled on a timely basis. Everytime a new request to `tweetsFromDB` comes in, it is either inserted into the Topics collection, or if it already exists, its priority is set to 1, the highest. Everytime the crawler crawls a given topic, the priority of that topic is increased by 1.

The crawler sleeps for x amount of seconds between crawls so as not to trigger twitter's API limits. Since we use a per-user approach, the more tokens we have, the less we have to sleep between calls. Since twitter refreshes limits every fifteen minutes, the more time left to the next refresh, the more time we have to sleep in between calls. So the crawler determines the amount of time to sleep using this equation.

``
minTimeInSeconds = remainingTimeInSeconds / remainingUses
``

`remainingUses` is originally set to number of tokens multiplied by the number of calls allowed and decremented everytime a token is retrieved (this assumes that the token is used for exactly one call once retrieved.

Finally the crawler figures out the minimum time, adds a 50% buffer for safety and sleeps for that amount of time.