### PR TITLE
Fixed Hot URLs not showing up

### DIFF
--- a/site/trendspedia/DEPLOY.md
+++ b/site/trendspedia/DEPLOY.md
@@ -42,7 +42,7 @@ rabbitmq-server -detached
 
 Make sure there is at least one celery worker scraping URLs in tweets.
 ``
-python manage.py celery -A twitter.taskrunner worker
+python manage.py celery worker -A twitter.taskrunner --autoscale=16,3 -f log/twitter.taskrunner.log -D
 ``
 
 ## Gunicorn
@@ -52,7 +52,6 @@ used for development.
 
 To run it, use  
 `gunicorn cs3281.wsgi:application --bind 127.0.0.1:8001 -D`  
-
 The `-D` runs it in daemonized mode. Adjust other options as required.
 The port is important because this port is where nginx will send
 requests to.

--- a/site/trendspedia/twitter/helper.py
+++ b/site/trendspedia/twitter/helper.py
@@ -1,5 +1,6 @@
 # Standard library import
 import json
+from bson import json_util
 import time
 from collections import defaultdict
 import operator
@@ -87,24 +88,22 @@ class Helper(object):
                 data = '%s(%s);' % (request.REQUEST['callback'], data)
                 return HttpResponse(str(data), "text/javascript")
         except:
-            data = json.dumps(result)
+            data = json.dumps(result, default=json_util.default)
         return HttpResponse(str(data), "application/json")
 
     def getHotMaterials(self, pageID):
         entries = Hot.objects(pageID=pageID).order_by('-mentionedCount').limit(500)
-
-        #sortedURL = sorted(appearances.iteritems(), key=operator.itemgetter(1), reverse=True)
-        sortedURL = [{"title":str(entry.title),
-		     "description":str(entry.description),	
-		     "url": str(entry.url),
-                     "count": str(entry.mentionedCount),
-                     "tweetID": str(entry.tweetID),
-                     "tweetCreatedTime": str(entry.tweetCreatedTime),
-                     "images": (entry.images)
-                     } 
-                     for entry in entries
-                    ]
-        return sortedURL
+        # TODO LOWPRIO: Is it necessary to convert like this at all?
+        sortedUrls = [{
+            "title":entry.title,
+            "description":entry.description,
+            "url": entry.url,
+            "count": entry.mentionedCount,
+            "tweetID": entry.tweetID,
+            "tweetCreatedTime": entry.tweetCreatedTime,
+            "images": entry.images
+        } for entry in entries ]
+        return sortedUrls
 
     '''
     def getHotImage(self, pageID):

--- a/site/trendspedia/twitter/mongoModels.py
+++ b/site/trendspedia/twitter/mongoModels.py
@@ -137,4 +137,5 @@ class Hot(Document):
     mentionedCount = IntField(default=1)
     images = ListField()
     tweetCreatedTime = DateTimeField()
+    crawled = BooleanField(default=False)
 

--- a/site/trendspedia/twitter/taskrunner.py
+++ b/site/trendspedia/twitter/taskrunner.py
@@ -12,10 +12,9 @@ app = Celery('urls')
 
 @app.task
 def summarize(id):
-  print "id=" + str(id)
   page = Hot.objects(pk=id).first()
   url = page.url
-  page.title, page.description, page.images = extractContentFromUrl(url)
+  page.crawled, page.title, page.description, page.images = extractContentFromUrl(url)
   page.save()
 
 def extractContentFromUrl(url):
@@ -24,13 +23,15 @@ def extractContentFromUrl(url):
   (title, description, images[])
   """
   content = ""
+  crawled = False
   try:
     req = urllib2.Request(url)
     res = urllib2.urlopen(req)
     content = res.read()
+    crawled = True
     res.close()
   except urllib2.URLError as u:
-    print "URL ERROR: " + u.reason
+    print "URL ERROR: ", u.reason
   except urllib2.HTTPError as h:
     print "HTTP Error: ", h.code
   document = readable.Article(content, url=url, return_fragment=False)
@@ -44,4 +45,4 @@ def extractContentFromUrl(url):
   description = dom.get_text()
   images = map(lambda img: img.get('src'), dom.find_all('img'))
   print "Crawled " + url + " (" + title + ")"
-  return title, description, images
+  return crawled, title, description, images

--- a/site/trendspedia/twitter/views.py
+++ b/site/trendspedia/twitter/views.py
@@ -245,7 +245,6 @@ def get_date(record):
 min_time = pikachu.datetime.max
 max_time = pikachu.datetime.min
 def getEvents(request, topic):
-    return None
     # print "topic = ", topic
     # con = Connection()
     # db = con['cs3281']


### PR DESCRIPTION
The issue there was that certain urls in the top 500 hot urls contained unicode characters not representable in ascii, and hence the str() calls always failed in the /hotMaterials path, giving out a 500 error. I've removed the str calls and refactored the code up a bit.

The `json_util` line is to correctly parse python datetime objects into JSON. Please refer to this link for details: http://stackoverflow.com/questions/11875770/how-to-overcome-datetime-datetime-not-json-serializable-in-python

Also removed an errant `return None` in twitter/views.py which was used for development but somehow got on the repo.

I've updated DEPLOY.md with a better way to task celery workers such that celery spawns and destroys worker threads depending on load.

I've added a crawled property to the Hot document to denote whether the URL has been crawled and summarized.

