### PR TITLE
Better taskrunner

### DIFF
--- a/site/trendspedia/twitter/taskrunner.py
+++ b/site/trendspedia/twitter/taskrunner.py
@@ -14,8 +14,14 @@ app = Celery('urls')
 def summarize(id):
   page = Hot.objects(pk=id).first()
   url = page.url
-  page.crawled, page.title, page.description, page.images = extractContentFromUrl(url)
-  page.save()
+  page.crawled, page.url, page.title, page.description, page.images = extractContentFromUrl(url)
+  duplicate = Hot.objects(pk__ne=id, url=page.url).first()
+  if duplicate is None:
+    # No duplicate URLs, save the page
+    page.save()
+  else:
+    # Duplicate URLs exist in the DB, delete the page
+    page.delete()
 
 def extractContentFromUrl(url):
   """
@@ -44,5 +50,5 @@ def extractContentFromUrl(url):
     title = bigdom.title.string.strip()
   description = dom.get_text()
   images = map(lambda img: img.get('src'), dom.find_all('img'))
-  print "Crawled " + url + " (" + title + ")"
-  return crawled, title, description, images
+  print "Crawled " + res.geturl() + " (" + title + ")"
+  return crawled, res.geturl(), title, description, images

--- a/site/trendspedia/twitter/taskrunner.py
+++ b/site/trendspedia/twitter/taskrunner.py
@@ -15,7 +15,7 @@ def summarize(id):
   page = Hot.objects(pk=id).first()
   url = page.url
   page.crawled, page.url, page.title, page.description, page.images = extractContentFromUrl(url)
-  duplicate = Hot.objects(pk__ne=id, url=page.url).first()
+  duplicate = Hot.objects(pk__ne=id, url=page.url, crawled=True).first()
   if duplicate is None:
     # No duplicate URLs, save the page
     page.save()


### PR DESCRIPTION
Taskrunner will now follow any redirects in the original URL and record the last one (This would circumvent URL shorteners like t.co and bit.ly). If this final URL already exists in the database and is already crawled, the current URL (duplicate) is deleted from the DB.

Of course, this doesn't solve the problem of the large amounts of duplicates already existing in the database.