### PR TITLE
More robust taskrunner

### DIFF
--- a/site/trendspedia/twitter/taskrunner.py
+++ b/site/trendspedia/twitter/taskrunner.py
@@ -3,7 +3,8 @@ from celery import Celery
 from twitter.mongoModels import Hot
 
 import json
-import urllib2
+import urllib2, socket, sys
+from httplib import BadStatusLine
 import locale
 import breadability.readable as readable
 from bs4 import BeautifulSoup
@@ -13,15 +14,22 @@ app = Celery('urls')
 @app.task
 def summarize(id):
   page = Hot.objects(pk=id).first()
+  if page is None:
+    return
   url = page.url
   page.crawled, page.url, page.title, page.description, page.images = extractContentFromUrl(url)
-  duplicate = Hot.objects(pk__ne=id, url=page.url, crawled=True).first()
-  if duplicate is None:
-    # No duplicate URLs, save the page
+  duplicate = Hot.objects(pk__ne=id, url=page.url, crawled=True)
+  if len(duplicate) == 0 and page.crawled == True:
+    # No duplicate URLs and no errors in parsing, save the page
     page.save()
-  else:
-    # Duplicate URLs exist in the DB, delete the page
+  elif len(duplicate) != 0:
+    # Delete all duplicate URLs and insert page (updated version)
+    duplicate.delete()
+    page.save()
+  elif page.crawled == False:
+    # Errors in parsing (or exceptions etc..)
     page.delete()
+
 
 def extractContentFromUrl(url):
   """
@@ -35,20 +43,32 @@ def extractContentFromUrl(url):
     res = urllib2.urlopen(req)
     content = res.read()
     crawled = True
+    url = res.geturl()
     res.close()
   except urllib2.URLError as u:
-    print "URL ERROR: ", u.reason
+    if isinstance(u.reason, basestring):
+      print 'URLError:\t\t' + url + ' --> ' + u.reason.encode('utf-8').strip()
+    else:
+      print url, sys.exc_info()[0]
   except urllib2.HTTPError as h:
-    print "HTTP Error: ", h.code
+    print 'HTTPError:\t\t' + url + ' --> ' + h.code
+  except BadStatusLine:
+    print 'BadStatusLine:\t' + url
+  except:
+    print url, sys.exc_info()[0]
   document = readable.Article(content, url=url, return_fragment=False)
   encoding = locale.getpreferredencoding()
   reduced_content = document.readable.encode(encoding)
-  bigdom = BeautifulSoup(content)
-  dom = BeautifulSoup(reduced_content)
   title = ""
-  if bigdom.title:
-    title = bigdom.title.string.strip()
-  description = dom.get_text()
-  images = map(lambda img: img.get('src'), dom.find_all('img'))
-  print "Crawled " + res.geturl() + " (" + title + ")"
-  return crawled, res.geturl(), title, description, images
+  description = ""
+  images = []
+  if reduced_content == '<div id="readabilityBody" class="parsing-error"/>':
+    crawled = False
+  else:
+    bigdom = BeautifulSoup(content)
+    dom = BeautifulSoup(reduced_content)
+    if bigdom.title and bigdom.title.string:
+      title = bigdom.title.string.strip()
+    description = dom.get_text()
+    images = map(lambda img: img.get('src'), dom.find_all('img'))
+  return crawled, url, title, description, images


### PR DESCRIPTION
Made some significant changes to make taskrunner more robust

- Added a self cleaning functionality to the taskrunner that takes a URL, crawls it, delete all crawled duplicates from the database and then inserts itself. Over time, this should remove most of the duplicates from the database.
- Handles all exceptions such that workers won't hang (Celery time limit feature is not functional at this time apparently, I will upgrade celery once they add that in).
- Only logs problems and thus the logfile can be used to track which websites have banned us (a lot apparently).