### PR TITLE
tweetsFromDB route now takes in location,time filter params

### DIFF
--- a/site/trendspedia/twitter/helper.py
+++ b/site/trendspedia/twitter/helper.py
@@ -46,6 +46,7 @@ def tweetCreation(item, user, pageID):
                   userID=str(user["id"]),
                   name=user["name"],
                   screenname=user["screen_name"],
+                  location=item["coordinates"],
                   profileImageUrl=user["profile_image_url"],
                   urls=json.dumps(relatedUrls),
                   profileBackgroundImageUrl=user["profile_background_image_url"]).save()

--- a/site/trendspedia/twitter/mongoModels.py
+++ b/site/trendspedia/twitter/mongoModels.py
@@ -111,7 +111,7 @@ class Tweets(Document):
     name = StringField(max_length=100)
     urls = StringField(default="")
     screenname = StringField(max_length=100)
-    location = StringField(max_length=1000)
+    location = PointField()
     description = StringField(default="")
     profileImageUrl = StringField(max_length=1000)
     profileBackgroundImageUrl = StringField(default="")


### PR DESCRIPTION
ALL ARE OPTIONAL. If no filter params given, the database simply returns the latest 100 tweets.

`pageID` and `query`: Return tweets related to that page, the original behaviour
`sw` and `ne`: Return tweets that have location data that places them within the bounding box of sw and ne. sw and ne are comma separated longitude/latitude values
`before` and/or `after`: Return tweets that was tweeted before/after a date or within a range of dates. Both before and after date strings are expected to be UTC datestrings of the form `2015-05-29T09:36:03.435Z`
